### PR TITLE
[WIP] OccupiedEntry.replace_

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1236,7 +1236,6 @@ impl<K: Debug, V: Debug, S> Debug for Entry<'_, K, V, S> {
 ///
 /// [`Entry`]: enum.Entry.html
 pub struct OccupiedEntry<'a, K, V, S> {
-    #[allow(dead_code)] // remove when replace_ methods are implemented
     key: Option<K>,
     elem: Bucket<(K, V)>,
     table: &'a mut HashMap<K, V, S>,
@@ -1872,11 +1871,12 @@ impl<'a, K, V, S> OccupiedEntry<'a, K, V, S> {
     ///
     /// let my_key = Rc::new("Stringthing".to_string());
     ///
-    /// if let Entry::Occupied(entry) = map.entry(my_key) {
+    /// if let Entry::Occupied(entry) = map.entry(my_key.clone()) {
     ///     // Also replace the key with a handle to our other key.
     ///     let (old_key, old_value): (Rc<String>, u32) = entry.replace_entry(16);
     /// }
     ///
+    /// assert_eq!(map[&my_key], 16);
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace_entry(self, value: V) -> (K, V) {


### PR DESCRIPTION
First pass at implementing the `OccupiedEntry.replace_` in #4 

This is directly taken from `hashbrown`.

I see the existing warning in `src/map.rs` that the hashbrown implementation will not work (https://github.com/jonhoo/griddle/blob/13509e46953c0b24f93a2dc40690b422102c1ce3/src/map.rs#L1857-L1865)

However, I do not see where the bucket gets moved. Aren't the `replace_entry` and `replace_key` replacing the values in place?

I additionally ran a test with a million random inserts / replaces comparing the results of `griddle::HashMap` vs `hashbrown::HashMap` and it passed.

Do you have any guidance on better understanding / triggering the warning condition?

Thanks